### PR TITLE
Convert trello markdown to jira

### DIFF
--- a/cmd/sync.js
+++ b/cmd/sync.js
@@ -5,6 +5,7 @@ const trelloCards = require('../lib/trello')
 const prettyjson = require('prettyjson')
 const objectPath = require("object-path");
 const stripIndent = require('common-tags').stripIndent
+const markdown2confluence = require("markdown2confluence-cws");
 const config = require('../lib/config')
 const logger = require('../lib/logger')
 
@@ -53,7 +54,7 @@ const transformToJiraFormat = function (parentEpic, epicField, storyPointField, 
         id: parentEpic.fields.project.id
       },
       summary: card.summary,
-      description: `${card.description}\n[Trello link|${card.cardLink}]`,
+      description: `${markdown2confluence(card.description)}\n\n[Trello link|${card.cardLink}]`,
       fixVersions: parentEpic.fields.fixVersions ? parentEpic.fields.fixVersions.map(fv => {
         return {
           id: fv.id

--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
   "dependencies": {
     "common-tags": "^1.4.0",
     "jira-client": "^4.2.0",
-    "object-path": "^0.11.4",
     "json2csv": "^3.11.1",
+    "markdown2confluence-cws": "^2.0.4",
+    "object-path": "^0.11.4",
     "prettyjson": "^1.2.1",
     "trello": "^0.8.0",
     "winston": "^2.3.1",


### PR DESCRIPTION
## Motivation
Trello uses markdown for card descriptions, jira uses it's own markup language. When generating jira issues from trello cards, description in trello must be written in this jira style markup, so that it is properly rendered in jira. When writing description in trello, there is no way to quickly check that the format is correct, so it is easy to make mistake.

## What
This PR adds markdown2confluence package, which can convert markdown (trello style) to jira markup. This way it is possible to write descriptions in trello in trello syntax, then trira will convert it to jira markup when syncing.
