### PR TITLE
added prefix support for generating jira tickets from trello cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ trira target <jiraHost> --trello-key=<trello-key> --trello-token=<trello-token> 
 trira sync <trello-board-regexp> <jira-epic-name-or-key> --list-regexp '.*'
 ```
 
-There are further options available, such as which Trello columns will be synced or a card name regular expression for more granular filtering. For more details about command usage, run:
+There are further options available, such as which Trello columns will be synced or a card name regular expression for more granular filtering, custom prefix of the card names, etc. For more details about command usage, run:
 ```
 trira help sync
 ```

--- a/cmd/sync.js
+++ b/cmd/sync.js
@@ -144,6 +144,8 @@ const handler = function(argv) {
       // converting comma separated list of labels to array
       const labels = argv.addLabels === undefined ? [] : new String(argv.addLabels).split(',')
       
+      const prefix = argv.prefix === undefined ? '' : argv.prefix
+
       return trelloCards.get(configuration.trello, argv.boardRegexp, argv.listRegexp, argv.cardRegexp)
         .then(cards => {
           logger.debug(`${argv.dryRun ? 'Would' : 'Will'} create ${cards.length} issues in JIRA`)
@@ -152,6 +154,7 @@ const handler = function(argv) {
             card.labels = card.labels.concat(labels)
             // removing duplicates and empty items
             card.labels = [ ...new Set(card.labels)].filter(String)
+            card.summary = prefix + card.summary
           })
 
           return Promise.all([Promise.resolve(cards), argv.dryRun ? Promise.resolve([]) : pushCardsToJira(cards, argv.epic, configuration.jira) ])

--- a/cmd/sync.js
+++ b/cmd/sync.js
@@ -38,6 +38,10 @@ const builder = function (yargs) {
       describe: 'Comma separated list of labels to be added to JIRA issues',
       default: undefined
     })
+    .option('prefix', {
+      describe: 'Prefix to be added at the beginning of each of the cards names',
+      default: ''
+    })
     .demand(2)
     .help('help')
     .wrap(null)


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/INTLY-876

## Verification Steps
Run this command (which will not create the Jira tickets, but will print what would the created tickets look like (--dry-run). Note - you need to have access to RHMAP test plan on Trello and also have trira set up locally (trello env vars):

```
trira sync 'Test Plan: Self Managed' 'RHMAP-21801'  --add-labels=team-customer-success,test-case --list-regexp 'MUST PER BUILD' --dry-run --prefix='PDS '
```

## Checklist:

- [x] Code has been tested locally by PR requester

## Progress

- [x] Finished task
